### PR TITLE
Modern iterm activates after cd (Issue #2)

### DIFF
--- a/Open iTerm.app/Contents/document.wflow
+++ b/Open iTerm.app/Contents/document.wflow
@@ -56,6 +56,7 @@
     set dir_path to quoted form of (POSIX path of (folder of the front window as alias))
   end tell
   CD_to(dir_path)
+  tell application "iTerm" to activate
 end run
 
 on CD_to(theDir)

--- a/application/application.modern.applescript
+++ b/application/application.modern.applescript
@@ -3,6 +3,7 @@ on run {input, parameters}
     set dir_path to quoted form of (POSIX path of (folder of the front window as alias))
   end tell
   CD_to(dir_path)
+  tell application "iTerm" to activate
 end run
 
 on CD_to(theDir)


### PR DESCRIPTION
Re: Issue #2, I don't think we need to identify specific windows to focus on: this 1-line change seems to consistently bring the just-created window/tab into focus.  